### PR TITLE
Upgrading Xtext to version 2.28.0.

### DIFF
--- a/renderc/build.gradle
+++ b/renderc/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 subprojects {
-	ext.xtextVersion = '2.20.0'
+	ext.xtextVersion = '2.28.0'
 
 	apply plugin: 'java'
 	apply plugin: 'org.xtext.xtend'

--- a/renderc/io.opentelemetry.render/build.gradle
+++ b/renderc/io.opentelemetry.render/build.gradle
@@ -5,7 +5,7 @@ configurations {
 }
 
 dependencies {
-	mwe2 "org.eclipse.emf:org.eclipse.emf.mwe2.launch:2.11.1"
+	mwe2 "org.eclipse.emf:org.eclipse.emf.mwe2.launch:2.13.0"
 	mwe2 "org.eclipse.xtext:org.eclipse.xtext.common.types:${xtextVersion}"
 	mwe2 "org.eclipse.xtext:org.eclipse.xtext.xtext.generator:${xtextVersion}"
 	mwe2 "org.eclipse.xtext:xtext-antlr-generator:[2.1.1, 3)"


### PR DESCRIPTION
Maintenance releases between 2.20.0 and 2.28.0: https://www.eclipse.org/Xtext/releasenotes.html