### PR TITLE
Using relative includes in render-generated sources.

### DIFF
--- a/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/BpfGenerator.xtend
+++ b/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/BpfGenerator.xtend
@@ -37,7 +37,7 @@ class BpfGenerator {
 
     #include "jitbuf/jb.h"
 
-    #include "generated/«app.jb_h»"
+    #include "wire_message.h"
 
     #ifdef __cplusplus
     extern "C" {

--- a/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/ConnectionGenerator.xtend
+++ b/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/ConnectionGenerator.xtend
@@ -217,17 +217,14 @@ class ConnectionGenerator {
     #include "connection.h"
     #include "protocol.h"
     #include "auto_handle_converters.h"
+    #include "parsed_message.h"
 
     #include <util/log.h>
     #include <util/render.h>
 
     #include <algorithm>
 
-    /* message structs for decoding */
-    #include "generated/«app.jsrv_h»"
-
-    namespace «app.pkg.name» {
-    namespace «app.name» {
+    namespace «app.pkg.name»::«app.name» {
 
     /******************************************************************************
      * Message statistics
@@ -401,8 +398,7 @@ class ConnectionGenerator {
       }
     «ENDFOR»
 
-    } /* namespace «app.name» */
-    } /* namespace «app.pkg.name» */
+    } // namespace «app.pkg.name»::«app.name»
     '''
   }
 

--- a/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/ProtocolGenerator.xtend
+++ b/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/ProtocolGenerator.xtend
@@ -25,16 +25,17 @@ class ProtocolGenerator {
 
     #pragma once
 
+    #include "hash.h"
+
     #include <common/client_type.h>
     #include <jitbuf/perfect_hash.h>
-    #include <platform/types.h>
-    #include <generated/«app.pkg.name»/«app.name»/hash.h>
     «IF app.jit»
       #include <jitbuf/transform_builder.h>
     «ENDIF»
+    #include <platform/types.h>
 
-    #include <stdexcept>
     #include <chrono>
+    #include <stdexcept>
 
     namespace «app.pkg.name» {
     namespace «app.name» {
@@ -178,17 +179,16 @@ class ProtocolGenerator {
     '''
     #include "protocol.h"
     #include "transform_builder.h"
-    #include <iostream>
-    #include <util/log.h>
+    #include "parsed_message.h"
+    #include "wire_message.h"
 
-    /* message structs for decoding */
-    #include "generated/«app.jsrv_h»"
-    #include "generated/«app.jb_h»"
+    #include <util/log.h>
 
     #include <spdlog/fmt/fmt.h>
 
-    namespace «app.pkg.name» {
-    namespace «app.name» {
+    #include <iostream>
+
+    namespace «app.pkg.name»::«app.name» {
 
     /******************************************************************************
      * PROTOCOL CLASS: C'tor
@@ -456,8 +456,7 @@ class ProtocolGenerator {
       «ENDFOR»
     }
 
-    } /* namespace «app.name» */
-    } /* namespace «app.pkg.name» */
+    } // namespace «app.pkg.name»::«app.name»
     '''
   }
 }

--- a/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/SpanGenerator.xtend
+++ b/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/SpanGenerator.xtend
@@ -464,7 +464,7 @@ class SpanGenerator {
     #include "keys.h"
     #include "auto_handles.h"
 
-    #include <generated/«app.pkg.name»/metrics.h>
+    #include "../metrics.h"
 
     #include <util/short_string.h>
     #include <util/fixed_hash.h>
@@ -2418,11 +2418,8 @@ class SpanGenerator {
     «generatedCodeWarning()»
     #pragma once
 
+    #include "parsed_message.h"
     #include "weak_refs.h"
-
-    /* message structs for decoding */
-    #include "generated/«app.jsrv_h»"
-    #include "generated/«app.descriptor_h»"
 
     #include <platform/types.h>
 
@@ -2517,13 +2514,14 @@ class SpanGenerator {
     '''
     «generatedCodeWarning()»
 
-    #include <utility>
     #include "auto_handle_converters.h"
 
-    namespace «app.pkg.name» { /* pkg */
-    namespace «app.name» { /* app */
+    #include <utility>
+
+    namespace «app.pkg.name»::«app.name» {
 
     namespace auto_handle_converters {
+
     «FOR span : app.spans»
       /********************************************
       * «span.name»
@@ -2533,9 +2531,9 @@ class SpanGenerator {
       {}
 
     «ENDFOR»
-    } /* namespace auto_handle_converters */
-    } /* namespace «app.name» (app) */
-    } /* namespace «app.pkg.name» (pkg) */
+    } // namespace auto_handle_converters
+
+    } // namespace «app.pkg.name»::«app.name»
     '''
   }
 
@@ -2548,10 +2546,10 @@ class SpanGenerator {
     «generatedCodeWarning()»
     #pragma once
 
-    #include <generated/«app.pkg.name»/«app.name»/parsed_message.h>
-    #include <generated/«app.pkg.name»/«app.name»/wire_message.h>
-    #include <generated/«app.pkg.name»/«app.name»/protocol.h>
-    #include <generated/«app.pkg.name»/«app.name»/transform_builder.h>
+    #include "parsed_message.h"
+    #include "wire_message.h"
+    #include "protocol.h"
+    #include "transform_builder.h"
 
     #include <util/meta.h>
 

--- a/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/TransformBuilderGenerator.xtend
+++ b/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/TransformBuilderGenerator.xtend
@@ -25,16 +25,18 @@ class TransformBuilderGenerator {
     '''
     #pragma once
 
-    #include <stdexcept>
+    #include "hash.h"
+
     #include <jitbuf/perfect_hash.h>
-    #include <generated/«app.pkg.name»/«app.name»/hash.h>
-    #include <platform/types.h>
     «IF app.jit»
       #include <jitbuf/transform_builder.h>
     «ENDIF»
+    #include <platform/types.h>
 
-    namespace «app.pkg.name» {
-    namespace «app.name» {
+    #include <stdexcept>
+
+    namespace «app.pkg.name»::«app.name» {
+
     /******************************************************************************
      * TRANSFORM BUILDER
      ******************************************************************************/
@@ -81,8 +83,7 @@ class TransformBuilderGenerator {
       PerfectHash<xform_info, «app.hashSize», rpc_id_hash_fn> identity_xforms_;
     };
 
-    } /* namespace «app.name» */
-    } /* namespace «app.pkg.name» */
+    } // namespace «app.pkg.name»::«app.name»
     '''
   }
 
@@ -90,10 +91,9 @@ class TransformBuilderGenerator {
      '''
     #include "transform_builder.h"
 
-    /* message structs for decoding */
-    #include "generated/«app.jsrv_h»"
-    #include "generated/«app.jb_h»"
-    #include "generated/«app.descriptor_h»"
+    #include "parsed_message.h"
+    #include "wire_message.h"
+    #include "descriptor.h"
 
     /******************************************************************************
      * IDENTITY TRANSFORM IMPLEMENTATIONS

--- a/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/WriterGenerator.xtend
+++ b/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/WriterGenerator.xtend
@@ -29,15 +29,15 @@ class WriterGenerator {
     '''
     #pragma once
 
-    #include <generated/«app.jb_h»>
-    #include <generated/«app.jsrv_h»>
-    #include <generated/«app.pkg.name»/«app.name»/encoder.h>
+    #include "encoder.h"
+    #include "parsed_message.h"
+    #include "wire_message.h"
 
     #include <channel/ibuffered_writer.h>
     #include <platform/types.h>
+    #include <util/log.h>
 
     #include <spdlog/fmt/fmt.h>
-    #include <util/log.h>
 
     #include <functional>
     #include <stdexcept>
@@ -108,7 +108,7 @@ class WriterGenerator {
 
   private static def generateWriterCc(App app) {
     '''
-    #include <generated/«app.pkg.name»/«app.name»/writer.h>
+    #include "writer.h"
 
     namespace «app.pkg.name»::«app.name» {
 
@@ -141,8 +141,8 @@ class WriterGenerator {
     '''
     #pragma once
 
-    #include <generated/«app.jb_h»>
-    #include <generated/«app.jsrv_h»>
+    #include "parsed_message.h"
+    #include "wire_message.h"
 
     #include <channel/ibuffered_writer.h>
     #include <platform/types.h>
@@ -165,7 +165,7 @@ class WriterGenerator {
 
   private static def generateEncoderCc(App app) {
     '''
-    #include <generated/«app.pkg.name»/«app.name»/encoder.h>
+    #include "encoder.h"
 
     #include <util/log.h>
     #include <util/log_formatters.h>
@@ -174,8 +174,8 @@ class WriterGenerator {
 
     Encoder::Encoder() {}
     Encoder::~Encoder() {}
-    «FOR msg : app.spans.flatMap[messages].toSet»
 
+    «FOR msg : app.spans.flatMap[messages].toSet»
       /* «msg.name» */
       std::error_code Encoder::«msg.name»(IBufferedWriter &__buffer, u64 __tstamp«msg.commaPrototype») {
         /* allocate space on the stack, 64-bit aligned */
@@ -242,8 +242,8 @@ class WriterGenerator {
 
         return {};
       }
-    «ENDFOR»
 
+    «ENDFOR»
     } /* namespace «app.pkg.name»::«app.name» */
     '''
   }
@@ -252,13 +252,12 @@ class WriterGenerator {
     '''
     #pragma once
 
-    #include <generated/«app.pkg.name»/«app.name»/encoder.h>
+    #include "encoder.h"
+    #include "parsed_message.h"
+    #include "wire_message.h"
 
     #include <channel/ibuffered_writer.h>
     #include <platform/types.h>
-
-    #include <generated/«app.jb_h»>
-    #include <generated/«app.jsrv_h»>
 
     namespace «app.pkg.name»::«app.name» {
 
@@ -295,7 +294,7 @@ class WriterGenerator {
 
   private static def generateOtlpLogEncoderCc(App app) {
     '''
-    #include <generated/«app.pkg.name»/«app.name»/otlp_log_encoder.h>
+    #include "otlp_log_encoder.h"
 
     #include <jitbuf/jb.h>
     #include <util/log.h>


### PR DESCRIPTION
Especially problematic was using <generated/...> for includes, as this path is part of the build system and is unknown to the render compiler.