### PR TITLE
Disallow move from an auto_handle to a weak_ref.

### DIFF
--- a/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/SpanGenerator.xtend
+++ b/renderc/io.opentelemetry.render/src/io/opentelemetry/render/generator/SpanGenerator.xtend
@@ -1643,6 +1643,11 @@ class SpanGenerator {
         inline «span.name»(Index &index, location_type loc);
 
         /**
+         * Move from an auto-handle is prohibited.
+         */
+        «span.name»(::«app.pkg.name»::«app.name»::auto_handles::«span.name» &&auto_handle) = delete;
+
+        /**
          * @returns true if reference is valid
          */
         inline bool valid() const


### PR DESCRIPTION
This prevents potential for dangling weak_refs, e.g.:

  weak_refs::span ref = index.span.alloc();