### PR TITLE
Mount /sys/kernel/debug before attempting to clean up stale probes.

### DIFF
--- a/collector/kernel/entrypoint.sh
+++ b/collector/kernel/entrypoint.sh
@@ -35,7 +35,9 @@ else
 fi
 
 # cleanup kprobes previously created by the kernel collector
+mount -t debugfs none /sys/kernel/debug
 if [[ -f /sys/kernel/debug/tracing/kprobe_events ]]; then
+  echo "cleaning up stale kprobes..."
   tmpfile="${data_dir}/ebpf_net_kprobes"
   grep "ebpf_net_" /sys/kernel/debug/tracing/kprobe_events \
     | cut -d: -f2 | sed -e 's/^/-:/' > "$tmpfile"


### PR DESCRIPTION
Otherwise the `kprobe_events` file will not exist, and the `entrypoint.sh` script will silently skip the cleaning step.