### PR TITLE
Remove incorrect flag -log-console from docker run

### DIFF
--- a/docs/kernel-collector.md
+++ b/docs/kernel-collector.md
@@ -41,7 +41,6 @@ docker run -it --rm \
   --privileged \
   --pid host \
   --network host \
-  --log-console \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume /sys/fs/cgroup:/hostfs/sys/fs/cgroup \
   --volume /etc:/hostfs/etc \


### PR DESCRIPTION
TLDR; **Fixes**: Current docker command to run kernel-collector causes errors
Hi, 

Thanks for donating this project to Otel. Excited to get my hands on it.

New to otel-ebpf, but I've worked with opentelemetry sdks in other languages.

My expectations from this project is to get http spans using kernel collector and export them to my custom otel receiver. Are these viable ?

Command
```
docker run -it --rm \
  --env EBPF_NET_INTAKE_PORT="${EBPF_NET_INTAKE_PORT}" \
  --env EBPF_NET_INTAKE_HOST="${EBPF_NET_INTAKE_HOST}" \
  --privileged \
  --pid host \
  --network host \
  --log-console \
  --volume /var/run/docker.sock:/var/run/docker.sock \
  --volume /sys/fs/cgroup:/hostfs/sys/fs/cgroup \
  --volume /etc:/hostfs/etc \
  --volume /var/cache:/hostfs/cache \
  --volume /usr/src:/hostfs/usr/src \
  --volume /lib/modules:/hostfs/lib/modules \
  kernel-collector --log-console --no-log-file
```
Errors
```
unknown flag: --log-console
See 'docker run --help'.
```


Also getting error 
```
Unable to find image 'kernel-collector:latest' locally
docker: Error response from daemon: pull access denied for kernel-collector, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```