### PR TITLE
Fix for enabling az-id timeseries with --enable-az-id flag.

### DIFF
--- a/reducer/aggregation/agg_core.cc
+++ b/reducer/aggregation/agg_core.cc
@@ -34,16 +34,16 @@ void AggCore::disable_node_ip_field()
 }
 
 bool AggCore::id_id_enabled_ = false;
-bool AggCore::az_node_enabled_ = false;
+bool AggCore::az_id_enabled_ = false;
 
 void AggCore::enable_id_id()
 {
   id_id_enabled_ = true;
 }
 
-void AggCore::enable_az_node()
+void AggCore::enable_az_id()
 {
-  az_node_enabled_ = true;
+  az_id_enabled_ = true;
 }
 
 AggCore::AggCore(
@@ -128,6 +128,7 @@ void AggCore::write_standard_metrics(u64 t)
       otlp_metric_writer_,
       std::chrono::nanoseconds(metric_timestamp),
       id_id_enabled_,
+      az_id_enabled_,
       disabled_metrics_);
 
   auto az_az_writer = [&encoder, this](auto &&...args) {

--- a/reducer/aggregation/agg_core.h
+++ b/reducer/aggregation/agg_core.h
@@ -54,7 +54,7 @@ public:
   static void enable_id_id();
 
   // Enables generating az-node metrics.
-  static void enable_az_node();
+  static void enable_az_id();
 
   // How many top aggregation role/role pairs to show the count for in the
   // pipeline_aggregation_roles internal stat.
@@ -109,11 +109,11 @@ private:
   // Flag indicating whether using IP addresses in node spans is disabled.
   static bool node_ip_field_disabled_;
 
-  // Flag indicating whether node-node (id-id) timeseries should be outputted.
+  // Flag indicating whether id-id timeseries should be outputted.
   static bool id_id_enabled_;
 
-  // Flag indicating whether az-node timeseries should be outputted.
-  static bool az_node_enabled_;
+  // Flag indicating whether az-id timeseries should be outputted.
+  static bool az_id_enabled_;
 
   void on_timeslot_complete() override;
 

--- a/reducer/aggregation/tsdb_encoder.cc
+++ b/reducer/aggregation/tsdb_encoder.cc
@@ -21,6 +21,7 @@ TsdbEncoder::TsdbEncoder(
     Publisher::WriterPtr &otlp_metric_writer,
     std::chrono::nanoseconds timestamp,
     bool id_id_enabled,
+    bool az_id_enabled,
     const DisabledMetrics &disabled_metrics,
     std::optional<int> rollup_count)
     : metric_writers_(metric_writers),
@@ -28,6 +29,7 @@ TsdbEncoder::TsdbEncoder(
       otlp_metric_writer_(otlp_metric_writer),
       timestamp_(timestamp),
       id_id_enabled_(id_id_enabled),
+      az_id_enabled_(az_id_enabled),
       disabled_metrics_(disabled_metrics)
 {
   if (!metric_writers.empty()) {

--- a/reducer/aggregation/tsdb_encoder.h
+++ b/reducer/aggregation/tsdb_encoder.h
@@ -34,6 +34,7 @@ public:
       Publisher::WriterPtr &otlp_metric_writer,
       std::chrono::nanoseconds timestamp,
       bool id_id_enabled,
+      bool az_id_enabled,
       const DisabledMetrics &disabled_metrics,
       std::optional<int> rollup_count = std::nullopt);
 
@@ -71,7 +72,7 @@ private:
 
   std::chrono::nanoseconds timestamp_;
   bool id_id_enabled_{false};
-  bool az_node_enabled_{false};
+  bool az_id_enabled_{false};
   int reverse_{0};
 
   const DisabledMetrics &disabled_metrics_;

--- a/reducer/aggregation/tsdb_encoder.inl
+++ b/reducer/aggregation/tsdb_encoder.inl
@@ -42,7 +42,7 @@ void TsdbEncoder::operator()(
 void TsdbEncoder::operator()(
     u64 t, ::ebpf_net::aggregation::weak_refs::az_node &az_node, ::ebpf_net::metrics::METRICS &metrics, u64 interval)
 {
-  if (az_node_enabled_) {
+  if (az_id_enabled_) {
     if (!metric_writers_.empty()) {
       auto writer_num = az_node.loc() % metric_writers_.size();
       auto &metric_writer = metric_writers_[writer_num];

--- a/reducer/main.cc
+++ b/reducer/main.cc
@@ -194,7 +194,7 @@ int main(int argc, char *argv[])
   }
 
   if (enable_az_id.Get()) {
-    reducer::aggregation::AggCore::enable_az_node();
+    reducer::aggregation::AggCore::enable_az_id();
   }
 
   if (enable_autonomous_system_ip.Get()) {


### PR DESCRIPTION
The value of `az_id_enabled` was not being propagated to the tsdb encoder. Also made naming more consistent: using `az_id` instead of `az_node`.