### PR TITLE
Moving cgroup_attach_task probe handling to the process prober.

### DIFF
--- a/collector/kernel/cgroup_prober.cc
+++ b/collector/kernel/cgroup_prober.cc
@@ -54,7 +54,6 @@ CgroupProber::CgroupProber(
 
   // EXISTING cgroups v1
   probe_handler.start_probe(bpf_module, "on_cgroup_clone_children_read", "cgroup_clone_children_read");
-  probe_handler.start_probe(bpf_module, "on_cgroup_attach_task", "cgroup_attach_task");
 
   periodic_cb();
   check_cb("cgroup prober startup");

--- a/collector/kernel/process_prober.cc
+++ b/collector/kernel/process_prober.cc
@@ -21,6 +21,9 @@ ProcessProber::ProcessProber(
   probe_handler.start_probe(bpf_module, "on_cgroup_exit", "cgroup_exit");
   probe_handler.start_kretprobe(bpf_module, "onret_cgroup_exit", "cgroup_exit");
 
+  // STATE CHANGE (pid->cgroup)
+  probe_handler.start_probe(bpf_module, "on_cgroup_attach_task", "cgroup_attach_task");
+
   // START
   /* probe for new process info
    * Note that other functions we considered were:


### PR DESCRIPTION
The `cgroup_attach_task` event signals a process state change, so it should be a part of process instrumentation.
